### PR TITLE
DVX-290: add option to force-save the cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ jobs:
           sessionToken: "AQoDYXdzEJraDcqRtz123" # optional
           bucket: actions-cache # required
           use-fallback: true # optional, use github actions cache fallback, default true
+          force-save: true # optional, force save cache even the key was an exact match, will not save if the cache is read only, default false
 
           # actions/cache compatible properties: https://github.com/actions/cache
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}

--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,10 @@ inputs:
     description: "Read only mode, do not save cache"
     required: false
     default: "false"
+  force-save:
+    description: "Save cache even if key is matched"
+    required: false
+    default: "false"
   # zip-option:
   #   description: zip options
   #   required: false

--- a/src/save.ts
+++ b/src/save.ts
@@ -29,6 +29,10 @@ async function saveCache() {
       return;
     }
 
+    if (forceSave) {
+      core.info("Force save is enabled");
+    }
+
     const bucket = core.getInput("bucket", { required: true });
     // Inputs are re-evaluted before the post action, so we want the original key
     const key = core.getState(State.PrimaryKey);

--- a/src/save.ts
+++ b/src/save.ts
@@ -16,7 +16,9 @@ process.on("uncaughtException", (e) => core.info("warning: " + e.message));
 
 async function saveCache() {
   try {
-    if (isExactKeyMatch()) {
+    const forceSave = getInputAsBoolean("force-save");
+
+    if (!forceSave && isExactKeyMatch()) {
       core.info("Cache was exact key match, not saving");
       return;
     }


### PR DESCRIPTION
when `force-save` is true we will upload the cache even if the key was a match.
Tested and works here: https://github.com/productboard/pb-e2e-test-space-setup/actions/runs/6432233620/job/17467358314#step:5:4