### PR TITLE
ci: Remove checkout and sca from Aisle JIT scan workflow

### DIFF
--- a/.github/workflows/aisle-jit-scan.yml
+++ b/.github/workflows/aisle-jit-scan.yml
@@ -23,13 +23,9 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
       - uses: productboard/shared-workflows/.github/actions/jit-scan@049662c75ef011f3165aef8e32d9c4446d409da0 # main
         with:
           api_token: ${{ secrets.AISLE_API_TOKEN }}
-          api_url:   ${{ secrets.AISLE_API_URL }}
-          scan_types: sast,sca,licenses
+          api_url: ${{ secrets.AISLE_API_URL }}
+          scan_types: sast,licenses
           fail_on_findings: false

--- a/.github/workflows/aisle-jit-scan.yml
+++ b/.github/workflows/aisle-jit-scan.yml
@@ -23,7 +23,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: productboard/shared-workflows/.github/actions/jit-scan@049662c75ef011f3165aef8e32d9c4446d409da0 # main
+      - uses: productboard/shared-workflows/.github/actions/jit-scan@6e034ce790a4d426755d32c111ca5d6ffbe0bd5f # main
         with:
           api_token: ${{ secrets.AISLE_API_TOKEN }}
           api_url: ${{ secrets.AISLE_API_URL }}


### PR DESCRIPTION
Two fixes to the Aisle JIT scan workflow:
- **Remove `actions/checkout`** — not needed, the action reads context from GitHub event env vars and calls the Aisle API. No repo code needs to be on disk.
- **Remove `sca` from `scan_types`** — leaving `sast,licenses`.